### PR TITLE
Fix loop condition for ambient and music

### DIFF
--- a/engine/infrastructure/widgets.py
+++ b/engine/infrastructure/widgets.py
@@ -416,11 +416,7 @@ class SoundPlayer(QWidget):
         self, status: QMediaPlayer.MediaStatus
     ) -> None:
         """Handle media status changes for looping."""
-        if (
-            status == QMediaPlayer.EndOfMedia
-            and self.loop_mode
-            and self.media_player.playbackState() != QMediaPlayer.StoppedState
-        ):
+        if status == QMediaPlayer.EndOfMedia and self.loop_mode:
             # Restart the media for looping
             self.media_player.setPosition(0)
             self.media_player.play()


### PR DESCRIPTION
## Summary
- ensure ambient and music tracks loop by removing playback-state check

## Testing
- `flake8` *(fails: trailing whitespace etc.)*
- `python -m py_compile engine/infrastructure/widgets.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9cbba026883259b6da560e130742d