### PR TITLE
Introduce domain sound services and tests

### DIFF
--- a/engine/domain/sound.py
+++ b/engine/domain/sound.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+import random
+
+AUDIO_EXTENSIONS = {".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac"}
+
+
+@dataclass(frozen=True)
+class VolumeLevel:
+    value: float
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.value <= 1.0:
+            raise ValueError("Volume level must be between 0.0 and 1.0")
+
+
+@dataclass
+class Sound:
+    path: Path
+    loop: bool = False
+
+    def should_loop(self) -> bool:
+        return self.loop
+
+
+@dataclass
+class SoundFolder:
+    path: Path
+    sounds: List[Sound] = field(default_factory=list)
+
+    def scan(self) -> None:
+        if not self.path.exists() or not self.path.is_dir():
+            self.sounds = []
+            return
+        self.sounds = [
+            Sound(p)
+            for p in self.path.iterdir()
+            if p.is_file() and p.suffix.lower() in AUDIO_EXTENSIONS
+        ]
+
+    def random_sound(self) -> Optional[Sound]:
+        if not self.sounds:
+            return None
+        return random.choice(self.sounds)

--- a/tests/test_sound_domain.py
+++ b/tests/test_sound_domain.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine.domain.sound import Sound, SoundFolder, VolumeLevel
+
+
+def test_volume_level_validation():
+    VolumeLevel(0.5)
+    with pytest.raises(ValueError):
+        VolumeLevel(1.5)
+
+
+def test_sound_folder_scan_filters_audio(tmp_path):
+    (tmp_path / 'a.mp3').write_text('data')
+    (tmp_path / 'b.txt').write_text('data')
+    folder = SoundFolder(tmp_path)
+    folder.scan()
+    assert [s.path.name for s in folder.sounds] == ['a.mp3']
+
+
+def test_sound_folder_random_sound(tmp_path):
+    (tmp_path / 'a.mp3').write_text('data')
+    (tmp_path / 'b.mp3').write_text('data')
+    folder = SoundFolder(tmp_path)
+    folder.scan()
+    names = {folder.random_sound().path.name for _ in range(10)}
+    assert names <= {'a.mp3', 'b.mp3'}
+    assert names  # not empty
+
+
+def test_sound_looping_flag(tmp_path):
+    sound = Sound(tmp_path / 'a.mp3', loop=True)
+    assert sound.should_loop()
+    sound.loop = False
+    assert not sound.should_loop()


### PR DESCRIPTION
## Summary
- add `Sound`, `SoundFolder`, and `VolumeLevel` domain models
- refactor `SoundPlayer` to use domain services for folder scanning and random playback
- add unit tests for volume validation, folder scanning, random selection, and looping flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9cd9777908325b1e297bd66e7deb4