### PR TITLE
Fix metaclass conflict in SoundRepository

### DIFF
--- a/engine/application/repositories.py
+++ b/engine/application/repositories.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from PySide6.QtCore import QObject, Signal
 
 from engine.domain.sound import Sound
 
 
-class SoundRepository(QObject, ABC):
+# Create a metaclass that combines Qt's ``QObject`` metaclass with ``ABCMeta``.
+#
+# ``QObject`` classes use a special metaclass provided by PySide6. When
+# combined with ``ABC`` (which uses ``ABCMeta``), Python raises a metaclass
+# conflict. Subclassing both metaclasses resolves the issue and still allows the
+# use of ``@abstractmethod``.
+
+
+class _QObjectABCMeta(type(QObject), ABCMeta):
+    """Metaclass combining PySide6's QObject meta and ``ABCMeta``."""
+
+
+class SoundRepository(QObject, metaclass=_QObjectABCMeta):
     """Abstract repository controlling sound playback.
 
     Infrastructure implementations should handle the actual audio I/O.


### PR DESCRIPTION
## Summary
- combine PySide6 and ABC metaclasses for `SoundRepository`
- document metaclass rationale

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d98657108325aa3dad5ebfeba8f0