### PR TITLE
Fix Sound hashability for repository lookups

### DIFF
--- a/engine/domain/sound.py
+++ b/engine/domain/sound.py
@@ -15,13 +15,21 @@ class VolumeLevel:
             raise ValueError("Volume level must be between 0.0 and 1.0")
 
 
-@dataclass
+@dataclass(eq=False)
 class Sound:
     path: Path
     loop: bool = False
 
     def should_loop(self) -> bool:
         return self.loop
+
+    def __hash__(self) -> int:
+        return hash(self.path)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Sound):
+            return NotImplemented
+        return self.path == other.path
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- make `Sound` objects hashable and comparable by path
- allow using sounds as keys in dictionaries without errors

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9da8f29cc83259092316fc3ad57d7