### PR TITLE
Separate Qt styles into external QSS

### DIFF
--- a/engine/infrastructure/style.qss
+++ b/engine/infrastructure/style.qss
@@ -1,0 +1,234 @@
+/* Global styles for OpenBoard */
+
+QMainWindow {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #f8f9fa, stop:1 #e9ecef);
+}
+
+SoundSection {
+    background-color: white;
+    border: 2px solid #e0e0e0;
+    border-radius: 12px;
+}
+
+#headerWidget {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #2c3e50, stop:1 #34495e);
+    border-radius: 16px;
+}
+
+#titleLabel {
+    color: white;
+}
+
+#masterVolLabel {
+    color: white;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+#masterVolumeSlider::groove:horizontal {
+    border: 1px solid #34495e;
+    height: 8px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #95a5a6, stop:1 #7f8c8d);
+    margin: 2px 0;
+    border-radius: 4px;
+}
+#masterVolumeSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #3498db, stop:1 #2980b9);
+    border: 2px solid white;
+    width: 18px;
+    height: 18px;
+    margin: -6px 0;
+    border-radius: 9px;
+}
+#masterVolumeSlider::handle:horizontal:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #2980b9, stop:1 #21618c);
+}
+
+#masterVolumeValue {
+    color: white;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+#stopAllButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+       stop:0 #e74c3c, stop:1 #c0392b);
+    color: white;
+    border: none;
+    border-radius: 24px;
+    font-weight: bold;
+    font-size: 14px;
+}
+#stopAllButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+       stop:0 #c0392b, stop:1 #a93226);
+    border: 2px solid #fff;
+}
+#stopAllButton:pressed {
+    background: #a93226;
+}
+
+SoundPlayer {
+    background-color: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    margin: 4px;
+}
+SoundPlayer:hover {
+    border-color: #2196F3;
+}
+
+#playerNameLabel {
+    font-weight: bold;
+    font-size: 12px;
+    color: #333;
+    padding: 2px 6px;
+    background-color: transparent;
+}
+
+#playButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #4CAF50, stop:1 #45a049);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 10px;
+}
+#playButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #45a049, stop:1 #3d8b40);
+}
+#playButton:pressed {
+    background: #3d8b40;
+}
+
+#pauseButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #FF9800, stop:1 #F57C00);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 10px;
+}
+#pauseButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #F57C00, stop:1 #E65100);
+}
+#pauseButton:pressed {
+    background: #E65100;
+}
+
+#stopButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #f44336, stop:1 #da190b);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 10px;
+}
+#stopButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #da190b, stop:1 #c1170a);
+}
+#stopButton:pressed {
+    background: #c1170a;
+}
+
+#volumeTextLabel {
+    color: #666;
+    font-size: 10px;
+    font-weight: bold;
+}
+
+#volumeSlider::groove:horizontal {
+    border: 1px solid #ddd;
+    height: 4px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #f5f5f5, stop:1 #e0e0e0);
+    margin: 2px 0;
+    border-radius: 2px;
+}
+#volumeSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #2196F3, stop:1 #1976D2);
+    border: 1px solid white;
+    width: 12px;
+    height: 12px;
+    margin: -4px 0;
+    border-radius: 6px;
+}
+#volumeSlider::handle:horizontal:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #1976D2, stop:1 #1565C0);
+}
+
+#volumeValueLabel {
+    color: #666;
+    font-size: 10px;
+    font-weight: bold;
+    text-align: right;
+}
+
+#folderInfoLabel {
+    color: #888;
+    font-size: 9px;
+    font-style: italic;
+    padding: 0px 6px;
+}
+
+#noFolderLabel {
+    color: #999;
+    font-style: italic;
+    font-size: 14px;
+    padding: 40px 20px;
+    background-color: transparent;
+}
+
+#noFilesLabel {
+    color: #999;
+    font-style: italic;
+    font-size: 14px;
+    padding: 40px 20px;
+    background-color: transparent;
+    line-height: 1.5;
+}
+
+#dividerFrame {
+    color: #e0e0e0;
+    background-color: #e0e0e0;
+    border: none;
+    margin: 2px 8px;
+}
+
+#playersWidget {
+    background-color: #fafafa;
+}
+
+#sectionScrollArea {
+    border: none;
+    background-color: #fafafa;
+    border-radius: 0 0 12px 12px;
+}
+#sectionScrollArea QScrollBar:vertical {
+    background-color: #f0f0f0;
+    width: 12px;
+    border-radius: 6px;
+    margin: 0;
+}
+#sectionScrollArea QScrollBar::handle:vertical {
+    background-color: #c0c0c0;
+    border-radius: 6px;
+    min-height: 20px;
+}
+#sectionScrollArea QScrollBar::handle:vertical:hover {
+    background-color: #a0a0a0;
+}
+

--- a/engine/infrastructure/widgets.py
+++ b/engine/infrastructure/widgets.py
@@ -51,19 +51,6 @@ class SoundPlayer(QWidget):
         """Set up the player UI."""
         self.setMinimumHeight(80)
         self.setMaximumHeight(80)
-        self.setStyleSheet(
-            """
-            SoundPlayer {
-                background-color: white;
-                border: 1px solid #e0e0e0;
-                border-radius: 8px;  
-                margin: 4px;  
-            }
-            SoundPlayer:hover {
-                border-color: #2196F3;
-            }
-        """
-        )
 
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(12, 8, 12, 8)
@@ -80,17 +67,7 @@ class SoundPlayer(QWidget):
 
         self.name_label = QLabel(name_text)
         self.name_label.setWordWrap(True)
-        self.name_label.setStyleSheet(
-            """
-            QLabel {
-                font-weight: bold;
-                font-size: 12px;  
-                color: #333;
-                padding: 2px 6px;
-                background-color: transparent;
-            }
-        """
-        )
+        self.name_label.setObjectName("playerNameLabel")
         top_layout.addWidget(self.name_label, 1)
 
         main_layout.addLayout(top_layout)
@@ -104,90 +81,25 @@ class SoundPlayer(QWidget):
         self.play_button = QPushButton("▶")
         self.play_button.setFixedSize(28, 24)
         self.play_button.clicked.connect(self.play)
-        self.play_button.setStyleSheet(
-            """
-            QPushButton {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #4CAF50, stop:1 #45a049);
-                color: white;
-                border: none;
-                border-radius: 12px;  
-                font-weight: bold;
-                font-size: 10px; 
-            }
-            QPushButton:hover {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #45a049, stop:1 #3d8b40);
-            }
-            QPushButton:pressed {
-                background: #3d8b40;
-            }
-        """
-        )
+        self.play_button.setObjectName("playButton")
         bottom_layout.addWidget(self.play_button)
 
         self.pause_button = QPushButton("⏸")
         self.pause_button.setFixedSize(28, 24)
         self.pause_button.clicked.connect(self._pause)
-        self.pause_button.setStyleSheet(
-            """
-            QPushButton {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #FF9800, stop:1 #F57C00);
-                color: white;
-                border: none;
-                border-radius: 12px;
-                font-weight: bold;
-                font-size: 10px;
-            }
-            QPushButton:hover {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #F57C00, stop:1 #E65100);
-            }
-            QPushButton:pressed {
-                background: #E65100;
-            }
-        """
-        )
+        self.pause_button.setObjectName("pauseButton")
         self.pause_button.hide()
         bottom_layout.addWidget(self.pause_button)
 
         self.stop_button = QPushButton("⏹")
         self.stop_button.setFixedSize(28, 24)
         self.stop_button.clicked.connect(self.stop)
-        self.stop_button.setStyleSheet(
-            """
-            QPushButton {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #f44336, stop:1 #da190b);
-                color: white;
-                border: none;
-                border-radius: 12px;
-                font-weight: bold;
-                font-size: 10px;
-            }
-            QPushButton:hover {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #da190b, stop:1 #c1170a);
-            }
-            QPushButton:pressed {
-                background: #c1170a;
-            }
-        """
-        )
+        self.stop_button.setObjectName("stopButton")
         bottom_layout.addWidget(self.stop_button)
 
         # Volume controls (inline)
         vol_label = QLabel("Vol:")
-        vol_label.setStyleSheet(
-            """
-            QLabel {
-                color: #666;
-                font-size: 10px;   
-                font-weight: bold;
-            }
-        """
-        )
+        vol_label.setObjectName("volumeTextLabel")
         bottom_layout.addWidget(vol_label)
 
         self.volume_slider = QSlider(Qt.Horizontal)
@@ -195,45 +107,12 @@ class SoundPlayer(QWidget):
         self.volume_slider.setValue(70)
         self.volume_slider.setFixedHeight(16)
         self.volume_slider.valueChanged.connect(self._on_volume_changed)
-        self.volume_slider.setStyleSheet(
-            """
-            QSlider::groove:horizontal {
-                border: 1px solid #ddd;
-                height: 4px;  
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #f5f5f5, stop:1 #e0e0e0);
-                margin: 2px 0;
-                border-radius: 2px;
-            }
-            QSlider::handle:horizontal {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #2196F3, stop:1 #1976D2);
-                border: 1px solid white;
-                width: 12px;  
-                height: 12px;
-                margin: -4px 0;
-                border-radius: 6px;
-            }
-            QSlider::handle:horizontal:hover {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #1976D2, stop:1 #1565C0);
-            }
-        """
-        )
+        self.volume_slider.setObjectName("volumeSlider")
         bottom_layout.addWidget(self.volume_slider, 1)
 
         self.volume_label = QLabel("70%")
         self.volume_label.setFixedWidth(30)
-        self.volume_label.setStyleSheet(
-            """
-            QLabel {
-                color: #666;
-                font-size: 10px;
-                font-weight: bold;
-                text-align: right;
-            }
-        """
-        )
+        self.volume_label.setObjectName("volumeValueLabel")
         bottom_layout.addWidget(self.volume_label)
 
         main_layout.addLayout(bottom_layout)
@@ -241,16 +120,7 @@ class SoundPlayer(QWidget):
         # Add folder info if this is a folder
         if self.is_folder:
             info_label = QLabel(f"({len(self.sound_folder.sounds)} sounds)")
-            info_label.setStyleSheet(
-                """
-                QLabel {
-                    color: #888;
-                    font-size: 9px;
-                    font-style: italic;
-                    padding: 0px 6px;
-                }
-            """
-            )
+            info_label.setObjectName("folderInfoLabel")
             main_layout.addWidget(info_label)
 
     def play(self) -> None:
@@ -346,32 +216,10 @@ class SoundSection(QWidget):
         scroll_area.setWidgetResizable(True)
         scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        scroll_area.setStyleSheet(
-            """
-            QScrollArea {
-                border: none;
-                background-color: #fafafa;
-                border-radius: 0 0 12px 12px;
-            }
-            QScrollBar:vertical {
-                background-color: #f0f0f0;
-                width: 12px;
-                border-radius: 6px;
-                margin: 0;
-            }
-            QScrollBar::handle:vertical {
-                background-color: #c0c0c0;
-                border-radius: 6px;
-                min-height: 20px;
-            }
-            QScrollBar::handle:vertical:hover {
-                background-color: #a0a0a0;
-            }
-        """
-        )
+        scroll_area.setObjectName("sectionScrollArea")
 
         self.players_widget = QWidget()
-        self.players_widget.setStyleSheet("background-color: #fafafa;")
+        self.players_widget.setObjectName("playersWidget")
         self.players_layout = QVBoxLayout(self.players_widget)
         self.players_layout.setContentsMargins(8, 8, 8, 8)
         self.players_layout.setSpacing(6)
@@ -394,17 +242,7 @@ class SoundSection(QWidget):
                 f"📁 Folder '{self.folder_path}' not found"
             )
             no_folder_label.setAlignment(Qt.AlignCenter)
-            no_folder_label.setStyleSheet(
-                """
-                QLabel {
-                    color: #999;
-                    font-style: italic;
-                    font-size: 14px;
-                    padding: 40px 20px;
-                    background-color: transparent;
-                }
-            """
-            )
+            no_folder_label.setObjectName("noFolderLabel")
             self.players_layout.addWidget(no_folder_label)
             return
 
@@ -447,18 +285,7 @@ class SoundSection(QWidget):
 
             no_files_label = QLabel(message)
             no_files_label.setAlignment(Qt.AlignCenter)
-            no_files_label.setStyleSheet(
-                """
-                QLabel {
-                    color: #999;
-                    font-style: italic;
-                    font-size: 14px;
-                    padding: 40px 20px;
-                    background-color: transparent;
-                    line-height: 1.5;
-                }
-            """
-            )
+            no_files_label.setObjectName("noFilesLabel")
             self.players_layout.addWidget(no_files_label)
             return
 
@@ -477,16 +304,7 @@ class SoundSection(QWidget):
                 divider.setFrameShape(QFrame.HLine)
                 divider.setFrameShadow(QFrame.Sunken)
                 divider.setFixedHeight(1)
-                divider.setStyleSheet(
-                    """
-                    QFrame {
-                        color: #e0e0e0;
-                        background-color: #e0e0e0;
-                        border: none;
-                        margin: 2px 8px;
-                    }
-                """
-                )
+                divider.setObjectName("dividerFrame")
                 self.players_layout.addWidget(divider)
 
         # Add stretch to push players to the top

--- a/engine/infrastructure/windows.py
+++ b/engine/infrastructure/windows.py
@@ -32,16 +32,6 @@ class MusicBoardMainWindow(QMainWindow):
         self.setWindowTitle("🎛️ OpenBoard - TTRPG Audio Mixer")
         self.setGeometry(100, 100, 1400, 900)
 
-        # Modern styling
-        self.setStyleSheet(
-            """
-            QMainWindow {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #f8f9fa, stop:1 #e9ecef);
-            }
-        """
-        )
-
         # Central widget
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
@@ -72,15 +62,6 @@ class MusicBoardMainWindow(QMainWindow):
 
         # Add sections to layout with equal spacing
         for section in self.sections:
-            section.setStyleSheet(
-                """
-                SoundSection {
-                    background-color: white;
-                    border: 2px solid #e0e0e0;
-                    border-radius: 12px;
-                }
-            """
-            )
             sections_layout.addWidget(section, 1)  # Equal stretch factor
 
         main_layout.addLayout(sections_layout)
@@ -89,28 +70,14 @@ class MusicBoardMainWindow(QMainWindow):
         """Create the header with master controls."""
         header_widget = QWidget()
         header_widget.setFixedHeight(80)
-        header_widget.setStyleSheet(
-            """
-            QWidget {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #2c3e50, stop:1 #34495e);
-                border-radius: 16px;
-            }
-        """
-        )
+        header_widget.setObjectName("headerWidget")
         header_layout = QHBoxLayout(header_widget)
         header_layout.setContentsMargins(24, 16, 24, 16)
 
         # Title with icon
         title_label = QLabel("🎛️ OpenBoard")
         title_label.setFont(QFont("Arial", 22, QFont.Bold))
-        title_label.setStyleSheet(
-            """
-            QLabel {
-                color: white;
-            }
-        """
-        )
+        title_label.setObjectName("titleLabel")
         header_layout.addWidget(title_label)
 
         header_layout.addStretch()
@@ -122,15 +89,7 @@ class MusicBoardMainWindow(QMainWindow):
         volume_layout.setSpacing(12)
 
         master_vol_label = QLabel("Master Volume:")
-        master_vol_label.setStyleSheet(
-            """
-            QLabel {
-                color: white;
-                font-weight: bold;
-                font-size: 14px;
-            }
-        """
-        )
+        master_vol_label.setObjectName("masterVolLabel")
         volume_layout.addWidget(master_vol_label)
 
         self.master_volume_slider = QSlider(Qt.Horizontal)
@@ -140,44 +99,12 @@ class MusicBoardMainWindow(QMainWindow):
         self.master_volume_slider.valueChanged.connect(
             self._on_master_volume_changed
         )
-        self.master_volume_slider.setStyleSheet(
-            """
-            QSlider::groove:horizontal {
-                border: 1px solid #34495e;
-                height: 8px;
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #95a5a6, stop:1 #7f8c8d);
-                margin: 2px 0;
-                border-radius: 4px;
-            }
-            QSlider::handle:horizontal {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #3498db, stop:1 #2980b9);
-                border: 2px solid white;
-                width: 18px;
-                height: 18px;
-                margin: -6px 0;
-                border-radius: 9px;
-            }
-            QSlider::handle:horizontal:hover {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                    stop:0 #2980b9, stop:1 #21618c);
-            }
-        """
-        )
+        self.master_volume_slider.setObjectName("masterVolumeSlider")
         volume_layout.addWidget(self.master_volume_slider)
 
         self.master_volume_label = QLabel("80%")
         self.master_volume_label.setFixedWidth(40)
-        self.master_volume_label.setStyleSheet(
-            """
-            QLabel {
-                color: white;
-                font-weight: bold;
-                font-size: 14px;
-            }
-        """
-        )
+        self.master_volume_label.setObjectName("masterVolumeValue")
         volume_layout.addWidget(self.master_volume_label)
 
         header_layout.addWidget(volume_container)
@@ -186,27 +113,7 @@ class MusicBoardMainWindow(QMainWindow):
         stop_all_button = QPushButton("⏹ Stop All")
         stop_all_button.setFixedSize(120, 48)
         stop_all_button.clicked.connect(self._stop_all_sounds)
-        stop_all_button.setStyleSheet(
-            """
-            QPushButton {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                   stop:0 #e74c3c, stop:1 #c0392b);
-                color: white;
-                border: none;
-                border-radius: 24px;
-                font-weight: bold;
-                font-size: 14px;
-            }
-            QPushButton:hover {
-                background: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
-                   stop:0 #c0392b, stop:1 #a93226);
-                border: 2px solid #fff;
-            }
-            QPushButton:pressed {
-                background: #a93226;
-            }
-        """
-        )
+        stop_all_button.setObjectName("stopAllButton")
 
         header_layout.addWidget(stop_all_button)
 

--- a/music_board_app.py
+++ b/music_board_app.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 
 from PySide6.QtWidgets import (
     QApplication,
@@ -50,6 +51,12 @@ def main() -> int:
     app.setApplicationName("OpenBoard Audio Mixer")
 
     app.setStyle('Fusion')
+
+    # Load global stylesheet
+    style_path = Path(__file__).resolve().parent / "engine" / "infrastructure" / "style.qss"
+    if style_path.exists():
+        with open(style_path, "r", encoding="utf-8") as f:
+            app.setStyleSheet(f.read())
 
     create_sample_folders()
 


### PR DESCRIPTION
## Summary
- Move Qt widget styling into new `style.qss` file for centralized theming
- Load global stylesheet in `music_board_app.py`
- Replace inline `setStyleSheet` calls with object names for QSS targeting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd708de0832585a08b782053dfd3