### PR TITLE
Add refresh button to reload audio folders

### DIFF
--- a/engine/infrastructure/widgets.py
+++ b/engine/infrastructure/widgets.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -293,7 +293,10 @@ class SoundSection(QWidget):
         for i, item_path in enumerate(all_items):
             is_folder = os.path.isdir(item_path)
             player = SoundPlayer(
-                item_path, self.loop_mode, is_folder=is_folder, service=self._service
+                item_path,
+                self.loop_mode,
+                is_folder=is_folder,
+                service=self._service,
             )
             self.players.append(player)
             self.players_layout.addWidget(player)
@@ -314,3 +317,19 @@ class SoundSection(QWidget):
         """Stop all players in this section."""
         for player in self.players:
             player.stop()
+
+    def refresh(self) -> None:
+        """Reload sounds from the section's folder."""
+        # Stop any currently playing sounds
+        self.stop_all()
+
+        # Remove all existing player widgets and other layout items
+        while self.players_layout.count():
+            item = self.players_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+        # Clear current players list and repopulate
+        self.players = []
+        self._load_sounds()

--- a/engine/infrastructure/windows.py
+++ b/engine/infrastructure/windows.py
@@ -109,12 +109,17 @@ class MusicBoardMainWindow(QMainWindow):
 
         header_layout.addWidget(volume_container)
 
-        # Stop all button
+        # Refresh and Stop All buttons
+        refresh_button = QPushButton("🔄 Refresh")
+        refresh_button.setFixedSize(120, 48)
+        refresh_button.clicked.connect(self._refresh_all_sections)
+        refresh_button.setObjectName("refreshButton")
+        header_layout.addWidget(refresh_button)
+
         stop_all_button = QPushButton("⏹ Stop All")
         stop_all_button.setFixedSize(120, 48)
         stop_all_button.clicked.connect(self._stop_all_sounds)
         stop_all_button.setObjectName("stopAllButton")
-
         header_layout.addWidget(stop_all_button)
 
         main_layout.addWidget(header_widget)
@@ -129,3 +134,8 @@ class MusicBoardMainWindow(QMainWindow):
         """Stop all sounds in all sections."""
         for section in self.sections:
             section.stop_all()
+
+    def _refresh_all_sections(self) -> None:
+        """Refresh sound lists for all sections."""
+        for section in self.sections:
+            section.refresh()


### PR DESCRIPTION
## Summary
- add Refresh button in main window header
- allow refreshing all sections to rescan folders for new audio

## Testing
- `pytest`
- `flake8 engine/infrastructure/widgets.py engine/infrastructure/windows.py` (fails: line length/trailing whitespace in existing code)


------
https://chatgpt.com/codex/tasks/task_e_68a9e02912788325a113bccfe44ae288