### PR TITLE
Replace emoji icons with FontAwesome icons

### DIFF
--- a/engine/infrastructure/widgets.py
+++ b/engine/infrastructure/widgets.py
@@ -2,8 +2,8 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QFont
+from PySide6.QtCore import Qt, QSize
+from PySide6.QtGui import QFont, QIcon
 from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
@@ -17,6 +17,8 @@ from PySide6.QtWidgets import (
 
 from engine.application.services import AudioService
 from engine.domain.sound import Sound, SoundFolder
+
+ICON_DIR = Path(__file__).resolve().parent / "icons" / "svgs" / "solid"
 
 
 class SoundPlayer(QWidget):
@@ -63,9 +65,13 @@ class SoundPlayer(QWidget):
         # Sound name with folder indicator
         name_text = self.filename
         if self.is_folder:
-            name_text = f"📁 {self.filename} 🔄"  # Folder icon + repeat icon
+            folder_icon = (ICON_DIR / "folder.svg").as_posix()
+            repeat_icon = (ICON_DIR / "repeat.svg").as_posix()
+            name_text = (f"<img src='{folder_icon}'/> {self.filename} <img src='{repeat_icon}'/>")
 
-        self.name_label = QLabel(name_text)
+        self.name_label = QLabel()
+        self.name_label.setTextFormat(Qt.RichText)
+        self.name_label.setText(name_text)
         self.name_label.setWordWrap(True)
         self.name_label.setObjectName("playerNameLabel")
         top_layout.addWidget(self.name_label, 1)
@@ -78,20 +84,26 @@ class SoundPlayer(QWidget):
         bottom_layout.setSpacing(6)
 
         # Smaller buttons
-        self.play_button = QPushButton("▶")
+        self.play_button = QPushButton()
+        self.play_button.setIcon(QIcon(str(ICON_DIR / "play.svg")))
+        self.play_button.setIconSize(QSize(16, 16))
         self.play_button.setFixedSize(28, 24)
         self.play_button.clicked.connect(self.play)
         self.play_button.setObjectName("playButton")
         bottom_layout.addWidget(self.play_button)
 
-        self.pause_button = QPushButton("⏸")
+        self.pause_button = QPushButton()
+        self.pause_button.setIcon(QIcon(str(ICON_DIR / "pause.svg")))
+        self.pause_button.setIconSize(QSize(16, 16))
         self.pause_button.setFixedSize(28, 24)
         self.pause_button.clicked.connect(self._pause)
         self.pause_button.setObjectName("pauseButton")
         self.pause_button.hide()
         bottom_layout.addWidget(self.pause_button)
 
-        self.stop_button = QPushButton("⏹")
+        self.stop_button = QPushButton()
+        self.stop_button.setIcon(QIcon(str(ICON_DIR / "stop.svg")))
+        self.stop_button.setIconSize(QSize(16, 16))
         self.stop_button.setFixedSize(28, 24)
         self.stop_button.clicked.connect(self.stop)
         self.stop_button.setObjectName("stopButton")
@@ -184,8 +196,17 @@ class SoundSection(QWidget):
         layout.setSpacing(0)
 
         # Section header
-        header = QLabel(self.title)
-        header.setFont(QFont("Arial", 16, QFont.Bold))
+        if 'AMBIENT' in self.title:
+            icon_file = 'leaf.svg'
+        elif 'MUSIC' in self.title:
+            icon_file = 'music.svg'
+        else:
+            icon_file = 'bolt.svg'
+        icon_path = (ICON_DIR / icon_file).as_posix()
+        header = QLabel()
+        header.setTextFormat(Qt.RichText)
+        header.setText(f"<img src='{icon_path}'/> {self.title}")
+        header.setFont(QFont('Arial', 16, QFont.Bold))
         header.setAlignment(Qt.AlignCenter)
         header.setFixedHeight(60)
 
@@ -238,11 +259,13 @@ class SoundSection(QWidget):
         """Load sound files and folders from the folder in alphabetical order."""
         if not os.path.exists(self.folder_path):
             # Show message if folder doesn't exist
+            folder_icon = (ICON_DIR / 'folder.svg').as_posix()
             no_folder_label = QLabel(
-                f"📁 Folder '{self.folder_path}' not found"
+                f"<img src='{folder_icon}'/> Folder '{self.folder_path}' not found",
             )
+            no_folder_label.setTextFormat(Qt.RichText)
             no_folder_label.setAlignment(Qt.AlignCenter)
-            no_folder_label.setObjectName("noFolderLabel")
+            no_folder_label.setObjectName('noFolderLabel')
             self.players_layout.addWidget(no_folder_label)
             return
 
@@ -278,14 +301,23 @@ class SoundSection(QWidget):
 
         if not all_items:
             # Show message if no audio files or folders found
-            if "EFFECTS" in self.title:
-                message = "🎵 No audio files or folders found\nAdd audio files or folders with sounds!"
+            music_icon = (ICON_DIR / 'music.svg').as_posix()
+            if 'EFFECTS' in self.title:
+                message = (
+                    f"<img src='{music_icon}'/> No audio files or folders found"
+                    "<br>Add audio files or folders with sounds!"
+                )
             else:
-                message = "🎵 No audio files found\nDrop some music here!"
+                message = (
+                    f"<img src='{music_icon}'/> No audio files found"
+                    "<br>Drop some music here!"
+                )
 
-            no_files_label = QLabel(message)
+            no_files_label = QLabel()
+            no_files_label.setTextFormat(Qt.RichText)
+            no_files_label.setText(message)
             no_files_label.setAlignment(Qt.AlignCenter)
-            no_files_label.setObjectName("noFilesLabel")
+            no_files_label.setObjectName('noFilesLabel')
             self.players_layout.addWidget(no_files_label)
             return
 

--- a/engine/infrastructure/windows.py
+++ b/engine/infrastructure/windows.py
@@ -1,9 +1,8 @@
+from pathlib import Path
 from typing import List
 
-from PySide6.QtCore import (
-    Qt,
-)
-from PySide6.QtGui import QFont
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QFont, QIcon
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
@@ -16,6 +15,8 @@ from PySide6.QtWidgets import (
 
 from engine.infrastructure.services import QtAudioService
 from engine.infrastructure.widgets import SoundSection
+
+ICON_DIR = Path(__file__).resolve().parent / "icons" / "svgs" / "solid"
 
 
 class MusicBoardMainWindow(QMainWindow):
@@ -30,7 +31,8 @@ class MusicBoardMainWindow(QMainWindow):
     def _setup_ui(self) -> None:
         """Set up the main window UI."""
 
-        self.setWindowTitle("🎛️ OpenBoard - TTRPG Audio Mixer and Soundboard")
+        self.setWindowTitle("OpenBoard - TTRPG Audio Mixer and Soundboard")
+        self.setWindowIcon(QIcon(str(ICON_DIR / "sliders.svg")))
         self.setGeometry(100, 100, 1400, 900)
 
         # Central widget
@@ -50,13 +52,13 @@ class MusicBoardMainWindow(QMainWindow):
 
         # Create the three sections
         ambient_section = SoundSection(
-            "🌿 AMBIENT", "ambient", self.audio_service, loop_mode=True
+            "AMBIENT", "ambient", self.audio_service, loop_mode=True
         )
         music_section = SoundSection(
-            "🎵 MUSIC", "music", self.audio_service, loop_mode=True
+            "MUSIC", "music", self.audio_service, loop_mode=True
         )
         effects_section = SoundSection(
-            "⚡ EFFECTS", "effects", self.audio_service, loop_mode=False
+            "EFFECTS", "effects", self.audio_service, loop_mode=False
         )
 
         self.sections = [ambient_section, music_section, effects_section]
@@ -77,7 +79,10 @@ class MusicBoardMainWindow(QMainWindow):
         header_layout.setContentsMargins(24, 16, 24, 16)
 
         # Title with icon
-        title_label = QLabel("🎛️ OpenBoard")
+        icon = (ICON_DIR / "sliders.svg").as_posix()
+        title_label = QLabel()
+        title_label.setTextFormat(Qt.RichText)
+        title_label.setText(f"<img src='{icon}'/> OpenBoard")
         title_label.setFont(QFont("Arial", 22, QFont.Bold))
         title_label.setObjectName("titleLabel")
         header_layout.addWidget(title_label)
@@ -112,13 +117,15 @@ class MusicBoardMainWindow(QMainWindow):
         header_layout.addWidget(volume_container)
 
         # Refresh and Stop All buttons
-        refresh_button = QPushButton("🔄 Refresh")
+        refresh_button = QPushButton("Refresh")
+        refresh_button.setIcon(QIcon(str(ICON_DIR / "refresh.svg")))
         refresh_button.setFixedSize(120, 48)
         refresh_button.clicked.connect(self._refresh_all_sections)
         refresh_button.setObjectName("refreshButton")
         header_layout.addWidget(refresh_button)
 
-        stop_all_button = QPushButton("⏹ Stop All")
+        stop_all_button = QPushButton("Stop All")
+        stop_all_button.setIcon(QIcon(str(ICON_DIR / "stop.svg")))
         stop_all_button.setFixedSize(120, 48)
         stop_all_button.clicked.connect(self._stop_all_sounds)
         stop_all_button.setObjectName("stopAllButton")


### PR DESCRIPTION
## Summary
- Replace emoji labels with FontAwesome 7 icons across widgets and main window
- Add reusable icon directory references for consistent icon loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9eba06a50832591a0d3ee51519c84