### PR TITLE
Add spacing between icons and text for header buttons

### DIFF
--- a/engine/infrastructure/style.qss
+++ b/engine/infrastructure/style.qss
@@ -64,6 +64,10 @@ SoundSection {
     font-weight: bold;
     font-size: 14px;
 }
+#stopAllButton::icon,
+#refreshButton::icon {
+    margin-right: 6px;
+}
 #stopAllButton:hover {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
        stop:0 #c0392b, stop:1 #a93226);


### PR DESCRIPTION
## Summary
- ensure refresh and stop-all buttons show space between icon and label via QSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9fe5c46588325a3653ac67eb06458