### PR TITLE
Remove undefined variable causing SoundPlayer initialization error

### DIFF
--- a/engine/infrastructure/widgets.py
+++ b/engine/infrastructure/widgets.py
@@ -75,7 +75,6 @@ class SoundPlayer(QWidget):
         self.is_folder = is_folder
         self.is_stream = is_stream
         self._service = service
-        self._stream_resolved = stream_resolved
 
         if self.is_folder:
             self.sound_folder = SoundFolder(Path(file_path))


### PR DESCRIPTION
## Summary
- fix NameError on startup by removing reference to nonexistent `stream_resolved`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57d7660f88325951873c92f6c8ff1