### PR TITLE
Fix YouTube Music link resolution

### DIFF
--- a/tests/test_youtube_url_normalization.py
+++ b/tests/test_youtube_url_normalization.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from engine.infrastructure.widgets import resolve_youtube  # noqa: E402
+
+
+def test_music_youtube_url_normalized(monkeypatch):
+    def fake_youtube(url):
+        raise RuntimeError(url)
+
+    monkeypatch.setattr("pytube.YouTube", fake_youtube)
+
+    with pytest.raises(RuntimeError) as exc:
+        resolve_youtube("https://music.youtube.com/watch?v=dummy")
+
+    assert exc.value.args[0].startswith(
+        "https://www.youtube.com/watch?v=dummy"
+    )
+
+
+def test_youtu_be_url_normalized(monkeypatch):
+    def fake_youtube(url):
+        raise RuntimeError(url)
+
+    monkeypatch.setattr("pytube.YouTube", fake_youtube)
+
+    with pytest.raises(RuntimeError) as exc:
+        resolve_youtube("https://youtu.be/dummy")
+
+    assert exc.value.args[0].startswith(
+        "https://www.youtube.com/watch?v=dummy"
+    )


### PR DESCRIPTION
## Summary
- normalize music.youtube.com, youtu.be, and mobile YouTube links before resolving streams
- add regression tests covering these YouTube URL variants

## Testing
- `flake8 engine/infrastructure/widgets.py tests/test_youtube_url_normalization.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57f98306c8325a3462cada2191b93