### PR TITLE
Fix YouTube Music link resolution

### DIFF
--- a/engine/infrastructure/widgets.py
+++ b/engine/infrastructure/widgets.py
@@ -36,23 +36,71 @@ def colored_svg(name: str, color: str, size: int) -> QPixmap:
     return pixmap
 
 
+def _normalize_youtube_url(url: str) -> str:
+    """Normalize various YouTube URL forms to ``www.youtube.com/watch``."""
+    from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+    parsed = urlparse(url)
+    netloc = parsed.netloc
+    path = parsed.path
+    query = parsed.query
+
+    if netloc.startswith("music.youtube") or netloc.startswith("m.youtube"):
+        netloc = "www.youtube.com"
+
+    if netloc == "youtu.be":
+        video_id = path.lstrip("/")
+        params = dict(parse_qsl(query))
+        params.setdefault("v", video_id)
+        netloc = "www.youtube.com"
+        path = "/watch"
+        query = urlencode(params)
+
+    parsed = parsed._replace(netloc=netloc, path=path, query=query)
+    return urlunparse(parsed)
+
+
 def resolve_youtube(url: str) -> tuple[str, str]:
     """Return direct audio stream URL and title for a YouTube link."""
-    from pytube import YouTube
+    from functools import partial
+    from pytube import YouTube, innertube
 
-    yt = YouTube(url)
-    stream = (
-        yt.streams
-        .filter(only_audio=True, mime_type="audio/mp4")
-        .order_by("abr")
-        .desc()
-        .first()
-    )
-    if stream is None:
-        stream = yt.streams.filter(only_audio=True).order_by("abr").desc().first()
-    if stream is None:
-        raise ValueError("No audio stream found")
-    return stream.url, yt.title
+    url = _normalize_youtube_url(url)
+
+    # Some YouTube Music links fail for the default ``ANDROID_MUSIC`` client.
+    # Retry with a broader set of clients so that restricted videos still
+    # resolve. ``INNER_CLIENTS`` order mirrors pytube's preferred clients.
+    inner_clients = ["ANDROID_MUSIC", "ANDROID", "WEB"]
+    last_exc: Exception | None = None
+
+    for client in inner_clients:
+        original_inner = innertube.InnerTube
+        try:
+            innertube.InnerTube = partial(innertube.InnerTube, client=client)
+            yt = YouTube(url)
+            stream = (
+                yt.streams.filter(only_audio=True, mime_type="audio/mp4")
+                .order_by("abr")
+                .desc()
+                .first()
+            )
+            if stream is None:
+                stream = (
+                    yt.streams.filter(only_audio=True)
+                    .order_by("abr")
+                    .desc()
+                    .first()
+                )
+            if stream is not None:
+                return stream.url, yt.title
+        except Exception as exc:  # pragma: no cover - network errors
+            last_exc = exc
+        finally:
+            innertube.InnerTube = original_inner
+
+    if last_exc:
+        raise last_exc
+    raise ValueError("No audio stream found")
 
 
 class SoundPlayer(QWidget):
@@ -282,7 +330,7 @@ class SoundPlayer(QWidget):
                 )
             else:
                 current = self.volume_slider.value() / 100.0
-            
+
             def finish(s=self.sound, pos=position) -> None:
                 self._service.pause_sound(s)
                 self._service.set_sound_position(s, pos)

--- a/tests/test_youtube_client_fallback.py
+++ b/tests/test_youtube_client_fallback.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import urllib.error
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from engine.infrastructure.widgets import resolve_youtube  # noqa: E402
+
+
+class _FakeStream:
+    url = "stream"
+
+
+class _FakeQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def desc(self):
+        return self
+
+    def first(self):
+        return _FakeStream()
+
+
+class _FakeYT:
+    def __init__(self, url):
+        self.title = "title"
+        self.streams = _FakeQuery()
+
+
+def test_resolve_youtube_retries_on_error(monkeypatch):
+    calls = []
+
+    def fake_youtube(url):
+        calls.append(url)
+        if len(calls) < 3:
+            raise urllib.error.HTTPError(
+                url, 400, "Bad Request", None, None
+            )
+        return _FakeYT(url)
+
+    monkeypatch.setattr("pytube.YouTube", fake_youtube)
+
+    stream_url, title = resolve_youtube(
+        "https://music.youtube.com/watch?v=dummy"
+    )
+
+    assert stream_url == "stream"
+    assert title == "title"
+    assert len(calls) == 3

--- a/tests/test_youtube_url_normalization.py
+++ b/tests/test_youtube_url_normalization.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from engine.infrastructure.widgets import resolve_youtube  # noqa: E402
+
+
+def test_music_youtube_url_normalized(monkeypatch):
+    def fake_youtube(url):
+        raise RuntimeError(url)
+
+    monkeypatch.setattr("pytube.YouTube", fake_youtube)
+
+    with pytest.raises(RuntimeError) as exc:
+        resolve_youtube("https://music.youtube.com/watch?v=dummy")
+
+    assert exc.value.args[0].startswith(
+        "https://www.youtube.com/watch?v=dummy"
+    )
+
+
+def test_youtu_be_url_normalized(monkeypatch):
+    def fake_youtube(url):
+        raise RuntimeError(url)
+
+    monkeypatch.setattr("pytube.YouTube", fake_youtube)
+
+    with pytest.raises(RuntimeError) as exc:
+        resolve_youtube("https://youtu.be/dummy")
+
+    assert exc.value.args[0].startswith(
+        "https://www.youtube.com/watch?v=dummy"
+    )


### PR DESCRIPTION
## Summary
- normalize music.youtube.com, youtu.be, and mobile YouTube links before resolving streams
- retry resolution with multiple InnerTube clients to handle restrictive YouTube Music videos
- add regression tests covering normalization and client fallback

## Testing
- `flake8 engine/infrastructure/widgets.py tests/test_youtube_url_normalization.py tests/test_youtube_client_fallback.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57f98306c8325a3462cada2191b93